### PR TITLE
Fix error in sefran with empty last day

### DIFF
--- a/CODE/cgi-bin/sefran3.pl
+++ b/CODE/cgi-bin/sefran3.pl
@@ -352,9 +352,11 @@ if (!$date) {
 	my $last_d = qx(y=\$(find $SEFRAN3{ROOT} -maxdepth 1 -name "????" | sort | tail -n1);find \$y -maxdepth 1| sort | tail -n1 | xargs echo -n);
 	if ($last_d) {
 		$last_mn = qx/find $last_d -name "??????????????.png"|sort|tail -n1/;
-		$lmn = basename($last_mn);
-		my @lm = (substr($lmn,10,2),substr($lmn,8,2),substr($lmn,6,2),substr($lmn,4,2),substr($lmn,0,4));
-		$dt = (timegm(gmtime) - timegm(0,$lm[0],$lm[1],$lm[2],$lm[3]-1,$lm[4]-1900) - 60);
+		if ($last_mn) {
+			$lmn = basename($last_mn);
+			my @lm = (substr($lmn,10,2),substr($lmn,8,2),substr($lmn,6,2),substr($lmn,4,2),substr($lmn,0,4));
+			$dt = (timegm(gmtime) - timegm(0,$lm[0],$lm[1],$lm[2],$lm[3]-1,$lm[4]-1900) - 60);
+		}
 	}
 
 	# titre et heure courante


### PR DESCRIPTION
The sefran displays the following error in the log when the last day in the sefran ROOT directory has no minute file:
```
sefran3.pl: Month '-1' out of range 0..11 at /opt/webobs/WebObs-2.1.0/CODE/cgi-bin/sefran3.pl line 357.
```

This error also appears on an error web page that replaces the expected empty sefran when displaying `cgi-bin/sefran3.pl`. (This behaviour seems to have appeared sometime between WebObs versions 1.8.0 and 2.1.0).

This little commit prevents the error and allows the expected display of the empty sefran. This fixes #2 .

----
This Pull Request also tests a possible workflow for contributions: I did not create use a fork, as you (François) said you didn't want to see too much forks and branches. But I think using a branch is necessary and creating PR allows you to review all changes made to the code before their integration, which is a Good Thing® (you simply have to merge the PR if you agree with the changes, or ask for amendments if you don't). Thanks!