### PR TITLE
Fix redirection problem in sefran replay mode

### DIFF
--- a/CODE/cgi-bin/editMC3.pl
+++ b/CODE/cgi-bin/editMC3.pl
@@ -410,7 +410,7 @@ if ($err == 0) {
 	print "<script language=\"javascript\">";
 		print "window.opener.location.reload();";
 	if ($replay) {
-		print "window.location='/cgi-bin/$WEBOBS{CGI_SEFRAN3}?date=$date&replay=$id_evt';";
+		print "window.location='/cgi-bin/$WEBOBS{CGI_SEFRAN3}?date=$date&replay=$id_evt&s3=$s3&mc3=$mc3';";
 	} else {
 		# for Firefox: opens a "false" window to be allowed to close it...
 		print "window.open('','_parent','');window.close();";


### PR DESCRIPTION
The issue happens when using multiple SefraN.
When the user identifies seismic events in replay mode on the non-default SefraN, he is redirected to the default SefraN after validating the first event.
Whith this fix, the user will be redirected to the SefraN he came from.
The fix uses the URL parameters mc3 and s3.