### PR TITLE
save full logs for GipsyX processing

### DIFF
--- a/CODE/shells/gnss/download_orbit
+++ b/CODE/shells/gnss/download_orbit
@@ -12,14 +12,14 @@
 #
 if [ $# -lt 2 ]; then
 	echo "     Syntax: download_orbit DAYS DEST [options]"
-	echo "Description: downloads best avalaible orbit for chosen dates from the"
+	echo "Description: downloads best available orbit for chosen dates from the"
 	echo "             JPL secured web server (see "
 	echo "             https://sideshow.jpl.nasa.gov/pub/JPL_GNSS_Products)"
 	echo "  Arguments:"
 	echo "        DAYS = number of days to process (from start day)"
 	echo "        DEST = root directory where orbits shall be saved"
 	echo "    Options:"
-	echo "        -o ORBIT = type of orbit (Ultra, Rapid or Final)"
+	echo "        -o ORBIT = type of orbit (Ultra, Rapid, Final, or Rapid_GE)"
 	echo "        -d STARTDAY = days to start retrieving (YYYY/mm/dd)"
    	echo "        -r DAYS = remove orbit files older than DAYS days"
 	echo "        -v = verbose mode"
@@ -64,7 +64,7 @@ for (( i=1; i<=$#; i++)); do
 			if [ "$ORBIT" != "Rapid" ]; then
 				if [ "$ORBIT" != "Final" ]; then
 					if [ "$ORBIT" != "Rapid_GE" ]; then
-						echo "Error : Please enter orbit as Ultra, Rapid or Final"
+						echo "Error : Please enter orbit as Ultra, Rapid, Final, or Rapid_GE"
 						exit 0
 					fi
 				fi
@@ -126,7 +126,7 @@ for day in $DAYLIST; do
 				echo " OK."
 				break
 			else
-				echo " not yet avalaible!"
+				echo " not yet available!"
 			fi
 
 		else

--- a/CODE/shells/gnss/download_orbit
+++ b/CODE/shells/gnss/download_orbit
@@ -12,14 +12,14 @@
 #
 if [ $# -lt 2 ]; then
 	echo "     Syntax: download_orbit DAYS DEST [options]"
-	echo "Description: downloads best available orbit for chosen dates from the"
+	echo "Description: downloads best avalaible orbit for chosen dates from the"
 	echo "             JPL secured web server (see "
 	echo "             https://sideshow.jpl.nasa.gov/pub/JPL_GNSS_Products)"
 	echo "  Arguments:"
 	echo "        DAYS = number of days to process (from start day)"
 	echo "        DEST = root directory where orbits shall be saved"
 	echo "    Options:"
-	echo "        -o ORBIT = type of orbit (Ultra, Rapid, Final, or Rapid_GE)"
+	echo "        -o ORBIT = type of orbit (Ultra, Rapid or Final)"
 	echo "        -d STARTDAY = days to start retrieving (YYYY/mm/dd)"
    	echo "        -r DAYS = remove orbit files older than DAYS days"
 	echo "        -v = verbose mode"
@@ -64,7 +64,7 @@ for (( i=1; i<=$#; i++)); do
 			if [ "$ORBIT" != "Rapid" ]; then
 				if [ "$ORBIT" != "Final" ]; then
 					if [ "$ORBIT" != "Rapid_GE" ]; then
-						echo "Error : Please enter orbit as Ultra, Rapid, Final, or Rapid_GE"
+						echo "Error : Please enter orbit as Ultra, Rapid or Final"
 						exit 0
 					fi
 				fi
@@ -126,7 +126,7 @@ for day in $DAYLIST; do
 				echo " OK."
 				break
 			else
-				echo " not yet available!"
+				echo " not yet avalaible!"
 			fi
 
 		else

--- a/CODE/shells/gnss/gnss_run_gipsyx
+++ b/CODE/shells/gnss/gnss_run_gipsyx
@@ -75,7 +75,7 @@ if [ $# -lt 2 ]; then
 	echo "       -debug"
 	echo "            verbose mode & temporary folders will not be deleted"
 	echo "       -fullog"
-	echo "            Full log record. Temporary folders are stored in a .fullog.tar.gz zip file"
+	echo "            Full log record. Temporary folders are stored in a .fullog.tar.gz file"
 	echo ""
 	exit 0;
 fi
@@ -449,9 +449,18 @@ for station in $NODES; do
 					gzip -f $gipsylog
 				fi
                                 
-                                if [ -z $FULLOG ]; then
-                                        tar -zcf $gipsyfullog_targz $tmpdir
-                                fi
+                                if [[ -n $FULLOG ]]; then
+					curdir=`pwd`
+					cd $tmpdir
+					ntmpfil=`ls | wc -l`
+					if [[ $ntmpfil -le 1 ]]; then
+						echo "   full log not saved (tmp folder contains only the input RINEX)"
+					else
+                                       		tar -zcf $gipsyfullog_targz * 
+						cd $curdir
+						echo "   full log saved in $gipsyfullog_targz" 
+                	                fi
+				fi
 			else
 				echo "   no data to process in $RAW."
 			fi

--- a/CODE/shells/gnss/gnss_run_gipsyx
+++ b/CODE/shells/gnss/gnss_run_gipsyx
@@ -450,12 +450,12 @@ for station in $NODES; do
 				fi
                                 
                                 if [[ -n $FULLOG ]]; then
-					curdir=`pwd`
-					cd $tmpdir
-					ntmpfil=`ls | wc -l`
+					ntmpfil=`ls $tmpdir | wc -l`
 					if [[ $ntmpfil -le 1 ]]; then
 						echo "   full log not saved (tmp folder contains only the input RINEX)"
 					else
+						curdir=`pwd`
+						cd $tmpdir
                                        		tar -zcf $gipsyfullog_targz * 
 						cd $curdir
 						echo "   full log saved in $gipsyfullog_targz" 

--- a/CODE/shells/gnss/gnss_run_gipsyx
+++ b/CODE/shells/gnss/gnss_run_gipsyx
@@ -73,7 +73,9 @@ if [ $# -lt 2 ]; then
 	echo "       -lock"
 	echo "            creates a lock file to prevent multiple process of gnss_run_gipsyx"
 	echo "       -debug"
-	echo "            verbose mode"
+	echo "            verbose mode & temporary folders will not be deleted"
+	echo "       -fullog"
+	echo "            Full log record. Temporary folders are stored in a .fullog.tar.gz zip file"
 	echo ""
 	exit 0;
 fi
@@ -170,8 +172,12 @@ for (( i=1; i<=$#; i++)); do
 		;;
    	-debug)
       		DEBUG=1
-		export VERBOSE=Y
-      		echo "Debug mode: temporary directories will NOT be deleted!"
+		export VERBOSE=1 ## make raw2rinex VERBOSE
+      		echo "Debug mode: temporary folders will NOT be deleted!"
+		;;
+   	-fullog)
+      		FULLOG=1
+      		echo "Full log record: temporary folders will be stored in zip files"
 		;;
    	-s)
       		j=$((i+1))
@@ -269,6 +275,7 @@ for station in $NODES; do
 		gipsyres="$res.tdp"
 		gipsycov="$res.gdcov"
 		gipsylog="$res.log"
+		gipsyfullog_targz="$res.fullog.tar.gz" # will be used only if $FULLOG is activated
 
 		if [[ $FORCE == 0 && -s "$gipsyres" ]]; then
 			echo "   file $gipsyres [flinn] already exists..."
@@ -441,6 +448,10 @@ for station in $NODES; do
 					mv -f $LOG $gipsylog
 					gzip -f $gipsylog
 				fi
+                                
+                                if [ -z $FULLOG ]; then
+                                        tar -zcf $gipsyfullog_targz $tmpdir
+                                fi
 			else
 				echo "   no data to process in $RAW."
 			fi


### PR DESCRIPTION
here is a new option `-fullog` for `gnss_run_gipsyx` which saves all the intermediate files stored in the tmp folder in a gzipped tarball at the end of the processing.  

The goal is to have a better insight into the processing and a better traceability of the results