### PR TITLE
gnss run gipsyx: clarify debug & fullog behavior

### DIFF
--- a/CODE/shells/gnss/gnss_run_gipsyx
+++ b/CODE/shells/gnss/gnss_run_gipsyx
@@ -131,12 +131,20 @@ DAYLIST=$(for d in $(seq $DAYS -1 0);do date -u -d "$d day ago" +"%Y/%m/%d";done
 
 LOG=gd2e.log
 
-# boolean for forcing process (default value doesn't force)
-FORCE=0
+
 
 if [ -z "$ERROR_REGEX_RINEX" ]; then
 	ERROR_REGEX_RINEX="REC #|ANT #|# / TYPES OF OBSERV|MARKER NAME"
 fi
+
+# boolean for forcing process (default value doesn't force)
+if [ -z "$FORCE" ] && FORCE=0 
+
+# boolean for enabling debug mode (default value doesn't)
+[ -z "$DEBUG" ] && DEBUG=0 
+
+# boolean for enabling full log mode (default value doesn't)
+[ -z "$FULLOG" ] && FULLOG=0
 
 
 # do not use non fiducial (NF) orbits per default
@@ -388,7 +396,7 @@ for station in $NODES; do
 
 						cmd="gd2e.py -rnxFile $rinex -GNSSproducts $ORBITOPT $GIPSYOPTIONS $NFORBOPTIONS"
 						echo "   $cmd"
-						if [ -z $DEBUG ]; then
+						if [ $DEBUG -eq 0 ]; then
 							eval "$cmd > $LOG 2>&1"
 						else
 							eval $cmd
@@ -403,7 +411,7 @@ for station in $NODES; do
 							       	trsprm="$ORBITSDIR/$product/$yyyy/$yyyy-$mm-$dd.x.gz"
 							        cmdtrans="netApply.py -t -r -s -i $cov -o ${cov}_trs -x $trsprm"
 								echo "   $cmdtrans"
-								if [ -z $DEBUG ]; then
+								if [ $DEBUG -eq 0 ]; then
 									eval "$cmdtrans > $LOG 2>&1"
 								else
 									eval $cmdtrans
@@ -449,7 +457,7 @@ for station in $NODES; do
 					gzip -f $gipsylog
 				fi
                                 
-                                if [[ -n $FULLOG ]]; then
+                                if [[ $FULLOG -eq 1 ]]; then
 					ntmpfil=`ls $tmpdir | wc -l`
 					if [[ $ntmpfil -le 1 ]]; then
 						echo "   full log not saved (tmp folder contains only the input RINEX)"
@@ -470,7 +478,7 @@ done
 
 echo "*************************************"
 
-if [ -z $DEBUG ]; then
+if [ $DEBUG -eq 0 ]; then
 	rm -rf $tmpdir
 fi
 

--- a/CODE/shells/gnss/gnss_run_gipsyx_template.rc
+++ b/CODE/shells/gnss/gnss_run_gipsyx_template.rc
@@ -76,7 +76,7 @@ DEBUG=0
 # Temporary folders are stored in a .fullog.tar.gz file
 FULLOG=0
 
-###### Advenced geodetic modes
+###### Advanced geodetic modes
 
 ### use fiducial (regular) or non-fiducial (NF) orbits. 
 # NFORB option will add '-prodTypeGNSS nf -gdCov' in the GIPSYOPTIONS

--- a/CODE/shells/gnss/gnss_run_gipsyx_template.rc
+++ b/CODE/shells/gnss/gnss_run_gipsyx_template.rc
@@ -3,7 +3,7 @@
 # directory). Please copy, rename and edit it for each "network".
 #
 # Created: 2019-02-25
-# Updated: 2021-02-09
+# Updated: 2025-01-17
 
 # main temporary directory (/tmp per default, change is recommended)
 TMPDIRMAIN=/tmp
@@ -47,6 +47,7 @@ ORBITSDIR=/home/wo/GNSS/JPL_Local_Orbits
 
 # download_orbit options (see download_orbit)
 DOWNLOAD_OPTIONS="-r 30"
+# "-r 30": orbits older than 30 day are removed
 
 # gd2e.py options
 GIPSYOPTIONS="-runType PPP"
@@ -66,8 +67,16 @@ REALTIME=""
 # data delay for realtime processing
 DATA_DELAY="5 min"
 
-# save full log
+###### Processing details management
+## activate debug mode
+# verbose mode & temporary folders will not be deleted
+DEBUG=0
+
+## Full log record
+# Temporary folders are stored in a .fullog.tar.gz file
 FULLOG=0
+
+###### Advenced geodetic modes
 
 ### use fiducial (regular) or non-fiducial (NF) orbits. 
 # NFORB option will add '-prodTypeGNSS nf -gdCov' in the GIPSYOPTIONS


### PR DESCRIPTION
DEBUG & FULLOG are explicitly defined and set to 0 per default, and clarified behavior of these booleans in the code.
.e. `-eq 0` or `-eq 1` replace nasty `-n` or `-z`
DEBUG & FULLOG are in in the template rc